### PR TITLE
Added test that asserts error throwing + minor code style fixes

### DIFF
--- a/test.coffee
+++ b/test.coffee
@@ -1,6 +1,5 @@
 test = require "ava"
 {IncomingMessage} = require "http"
-Stream =  require "stream"
 {Socket} = require "net"
 
 busboy = require "."
@@ -10,12 +9,12 @@ test "Should return a plain object", (t) ->
   await return
 
 test "Should return a promise", (t) ->
-  req = request()
-  bb = busboy(req)
-  t.is bb instanceof Promise, true
+  t.is busboy(request()) instanceof Promise, true
+
+test "Should throw an error if request parameter isn't an instance of http.IncomingMessage", (t)->
+  t.throws(busboy({}), "Request parameter must be an instance of http.IncomingMessage.")
 
 request = ()->
-
   req = new IncomingMessage new Socket({readeble: true})
   req.headers =
     'content-type': 'multipart/form-data; boundary=----WebKitFormBoundaryoyYHBQpNew47X0cp'


### PR DESCRIPTION
Added one more test that asserts error throwing on passing parameter as not an instance of `http.IncomingMessage`:

``` coffeescript
 unless req instanceof IncomingMessage
    throw new TypeError "
      Request parameter must be an instance of http.IncomingMessage.
    "
```

 I have also fixed a few code styles issues. 
