### PR TITLE
Fix TypeScript not able to resolve types when set to Node16

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "types": "@type/index.d.ts",
   "exports": {
     "import": "./lib/esm/index.js",
-    "require": "./lib/cjs/index.js"
+    "require": "./lib/cjs/index.js",
+    "types": "./@type/index.d.ts"
   },
   "engines": {
     "node": ">= 12.4"


### PR DESCRIPTION
Fix type resolution when using TypeScript 4.7+ set to Node16 module resolution.